### PR TITLE
Write changelog and bump the version number to `v1.1.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## `v1.0.0` - TBD
+## `v1.1.0` - 08/09/2024
+
+### Changed
+
+- The hash to use the list of enabled resource packs on top of the mod list
+
+### Fixed
+
+- Mipmap levels not being saved to the cache, causing broken mipmaps when loading atlas textures from the cache
+- An occasional native crash when saving atlas textures to the cache
+
+## `v1.0.0` - 29/08/2024
 
 Initial release.

--- a/CHANGELOG_LATEST.md
+++ b/CHANGELOG_LATEST.md
@@ -1,1 +1,8 @@
-Initial release.
+### Changed
+
+- The hash to use the list of enabled resource packs on top of the mod list
+
+### Fixed
+
+- Mipmap levels not being saved to the cache, causing broken mipmaps when loading atlas textures from the cache
+- An occasional native crash when saving atlas textures to the cache

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,7 @@
 org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 org.gradle.caching=true
+
 # Mod properties
 maven_group=io.github.steveplays28
 mod_id=blinkload
@@ -10,9 +11,10 @@ mod_namespace=blinkload
 mod_name=BlinkLoad
 mod_description=Caches assets to reduce game loading times.
 mod_license=LGPL-3.0
-mod_version=1.0.0
+mod_version=1.1.0
 supported_minecraft_version=>=1.20 <=1.20.1
 supported_minecraft_version_name=1.20-1.20.1
+
 # Multiloader properties
 architectury_plugin_version=3.4-SNAPSHOT
 architectury_loom_version=1.6-SNAPSHOT
@@ -20,16 +22,19 @@ shadow_plugin_version=7.1.2
 minecraft_version=1.20.1
 java_version=17
 enabled_platforms=fabric,forge
+
 # mc-publish properties
-# TODO
-curseforge_project_id=0
-modrinth_project_id=0
+curseforge_project_id=1082541
+modrinth_project_id=2qcrCATG
+
 # Fabric properties
 # Check these on https://modmuss50.me/fabric.html
 yarn_mappings=1.20.1+build.10
 fabric_loader_version=0.14.25
+
 # (Neo)Forge properties
 neoforge_version=47.1.100
+
 # Dependencies
 mixin_extras_version=0.3.5
 architectury_api_version=9.2.14


### PR DESCRIPTION
- Wrote a changelog
- Bumped the version number to `v1.1.0`
- Updated the CurseForge/Modrinth project IDs
